### PR TITLE
Add title attribute to widget error data

### DIFF
--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -93,6 +93,10 @@ export interface WidgetErrorData {
    */
   code: WidgetErrorCode;
   /**
+   * Localization key, such as `t_verification_failed`.
+   */
+  title?: string;
+  /**
    * More details about the error to help debugging.
    * This value is not localized and will change between versions.
    *


### PR DESCRIPTION
This PR adds the title attribute to the widget for use in https://github.com/FriendlyCaptcha/friendly-captcha/pull/1149. Wasn't sure about the naming... `title` seems the most correct one since it's used as a title when the widget is display with an error but on it's own it looks a bit off in `WidgetErrorData`.

Part of https://github.com/FriendlyCaptcha/friendly-captcha/issues/1148