### PR TITLE
Don't remove root element from the DOM on destroy

### DIFF
--- a/src/sdk/dom.ts
+++ b/src/sdk/dom.ts
@@ -60,6 +60,13 @@ export function setWidgetRootStyles(el: HTMLElement) {
   sinas(el, "borderRadius", "4px");
 }
 
+/**
+ * @internal
+ */
+export function removeWidgetRootStyles(el: HTMLElement) {
+  el.removeAttribute("style");
+}
+
 export function runOnDocumentLoaded(func: () => any) {
   if (document.readyState !== "loading") {
     func();

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -16,7 +16,7 @@ import {
   createWidgetPlaceholder,
 } from "./create.js";
 import { EnvelopedMessage, Message, RootSignalsGetMessage, ToAgentMessage, ToRootMessage } from "../types/messages.js";
-import { findCaptchaElements, setWidgetRootStyles } from "./dom.js";
+import { findCaptchaElements, removeWidgetRootStyles, setWidgetRootStyles } from "./dom.js";
 import { flatPromise } from "../util/flatPromise.js";
 import { WidgetHandle } from "./widgetHandle.js";
 import { Store } from "./persist.js";
@@ -311,7 +311,7 @@ export class FriendlyCaptchaSDK {
     const newWidgets: WidgetHandle[] = [];
     for (let index = 0; index < elements.length; index++) {
       const hElement = elements[index] as HTMLElement;
-      if (hElement && !(hElement as any ).frcWidget) {
+      if (hElement && !(hElement as any).frcWidget) {
         const ds = hElement.dataset;
         const opts: CreateWidgetOptions = {
           element: hElement,
@@ -352,7 +352,9 @@ export class FriendlyCaptchaSDK {
         send({ type: "root_destroy_widget" });
         this.bus.removeTarget(widgetId);
         this.widgets.delete(widgetId);
-        opts.element.remove();
+
+        opts.element.innerHTML = "";
+        removeWidgetRootStyles(opts.element);
       },
       onReset: () => {
         send({ type: "root_reset_widget" });


### PR DESCRIPTION
The element that the widget is bound to is not created by it and should therefore not be removed from the DOM when the widget is destroyed. Instead, this removes all children and the styling.