### PR TITLE
Limit `devicemotion` and `deviceorientation` to Android devices (by UA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## Unreleased
+
+* Fix `deviceorientation` and `devicemotion` deprecation warnings in Firefox browsers on desktop.
+
 ## 0.1.8
 **Date**: 2024-06-20
 

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -29,6 +29,14 @@ const M = Math;
 let ssig: Signals | undefined;
 
 /**
+ * Returns true if the browser is an Android device based on the user agent string (very naively).
+ * @internal 
+ */
+function isAndroidUA() {
+  return /Android/i.test(navigator.userAgent);
+}
+
+/**
  * Computes rolling stats of a variable.
  * Retrigger continuously resets the timer when subsequent "on" events happen.
  * @internal
@@ -350,6 +358,13 @@ export class Signals {
       g: false,
     };
 
+    if (!isAndroidUA()) {
+      // We limit this signal to Android phones, which is generally the only place where we would expect to get
+      // this data anyhow.
+      return sig;
+    }
+
+
     window[x]("devicemotion", (e) => {
       sig.ts = e.timeStamp;
       sig.i = e.interval;
@@ -381,6 +396,12 @@ export class Signals {
       gd: gd.s,
       bd: bd.s,
     };
+
+    if (!isAndroidUA()) {
+      // We limit this signal to Android phones, which is generally the only place where we would expect to get
+      // this data anyhow.
+      return sig;
+    }
 
     let hasPrevious: true | undefined;
     window[x]("deviceorientation", (e) => {


### PR DESCRIPTION
This removes the deprecation warning that is visible in some desktop browsers (notably Firefox).