### PR TITLE
Add test for Cross Origin Embedder Policy require-corp

### DIFF
--- a/sdktest/test/coep/body.tmpl.html
+++ b/sdktest/test/coep/body.tmpl.html
@@ -1,0 +1,12 @@
+<main>
+    <form>
+        <p>Cross Origin Embedder Policy of 'require-corp' can complete widget.</p>
+    
+        <input type="textarea"/>
+        <div class="frc-captcha" data-sitekey="{{ .Config.Sitekey }}"></div>
+        <input type="submit"/>
+    </form>
+</main>
+
+<script defer src="{{ .SiteJSPath }}"></script>
+<script defer src="main.tmpl.ts"></script>

--- a/sdktest/test/coep/config.tmpl.yaml
+++ b/sdktest/test/coep/config.tmpl.yaml
@@ -1,0 +1,3 @@
+headers:
+  cross-origin-embedder-policy: "require-corp"
+

--- a/sdktest/test/coep/main.tmpl.ts
+++ b/sdktest/test/coep/main.tmpl.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { sdktest } from "../../sdktestlib/sdk.js";
+
+sdktest.test({ name: "widget completes after starting" }, async (t) => {
+  t.require.numberOfWidgets(1);
+  const w = t.getWidget()!;
+  const completePromise = t.assert.widgetCompletes(w)
+  w.start();
+  
+  await completePromise;
+
+  // We destroy the widget to check the cleanup may trigger a CSP violation.
+  w.destroy();
+});
+


### PR DESCRIPTION
Add a test to ensure that site with a `Cross-Origin-Embedder-Policy` of `require-corp` is still able to use and complete the widget.