### PR TITLE
Don't wrap `Promise` constructor in older browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.11
+
+* Fix wrapping of Promise constructor, which lead to issues in Chrome <= 45 (released September 2015) and Firefox <= 40.
+
 ## 0.1.10
 
 * Fix use of ES features in non-compat build, which caused Safari 11.1 and 12.1 to fail to load the SDK.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "In-browser SDK for Friendly Captcha v2 (currently in preview only)",
   "main": "dist/sdk.js",
   "type": "module",

--- a/sdktest/render/script.go
+++ b/sdktest/render/script.go
@@ -11,7 +11,11 @@ import (
 	"github.com/evanw/esbuild/pkg/api"
 )
 
-func (r *TestCaseHandler) loadAndBuildScript(templates *template.Template, path string, renderData TestCaseRenderData) ([]byte, error) {
+func (r *TestCaseHandler) loadAndBuildScript(
+	templates *template.Template,
+	path string,
+	renderData TestCaseRenderData,
+) ([]byte, error) {
 	scriptEntry, err := executeTemplateIfExists(templates, path, renderData)
 	if err != nil {
 		return nil, err

--- a/src/signals/collectStacktrace.ts
+++ b/src/signals/collectStacktrace.ts
@@ -108,7 +108,7 @@ export const takeRecords = (function () {
     const hasGetterOrSetter = descriptor && (descriptor.get || descriptor.set);
 
     // We skip the patching of the constructor property if `Symbol.species` is not supported.
-    if (prop === c && !(window.Symbol && window.Symbol.species)) {
+    if (prop === c && !(w.Symbol && w.Symbol.species)) {
       return;
     }
 

--- a/src/signals/collectStacktrace.ts
+++ b/src/signals/collectStacktrace.ts
@@ -79,6 +79,7 @@ export const takeRecords = (function () {
 
   // We save some bundle size by using these constants.
   const p = "prototype";
+  const c = "constructor";
 
   // Safari 10.1 (and 10.3 on iOS) and earlier does not have `EventTarget` defined.
   const dispatchEvent = w.EventTarget ? w.EventTarget[p].dispatchEvent : {};
@@ -99,12 +100,17 @@ export const takeRecords = (function () {
     ["Document." + p + ".querySelectorAll", w.Document[p], "querySelectorAll"],
     ["Document." + p + ".createElement", w.Document[p], "createElement"],
     ["EventTarget." + p + ".dispatchEvent", dispatchEvent, "dispatchEvent"],
-    ["Promise." + p + "e.constructor", w.Promise[p], "constructor"],
+    ["Promise." + p + "." + c, w.Promise[p], c],
   ];
 
   patches.forEach(function ([name, target, prop]) {
     const descriptor = Object.getOwnPropertyDescriptor(target, prop);
     const hasGetterOrSetter = descriptor && (descriptor.get || descriptor.set);
+
+    // We skip the patching of the constructor property if `Symbol.species` is not supported.
+    if (prop === c && !(window.Symbol && window.Symbol.species)) {
+      return;
+    }
 
     if (!descriptor) {
       return;


### PR DESCRIPTION
Wrapping the `Promise` constructor causes issues in browsers that don't support `Symbol.species` - it now no longer wraps that constructor in those (8+ year old) browsers.