### PR TITLE
Handle `null` or `undefined` `postMessage` messages

### DIFF
--- a/src/communication/bus.ts
+++ b/src/communication/bus.ts
@@ -120,7 +120,7 @@ export class CommunicationBus {
     }
 
     const msg = ev.data as EnvelopedMessage<ToRootMessage>;
-    if (!msg._frc) return; // Message unrelated to Friendly Captcha.
+    if (!msg || !msg._frc) return; // Message unrelated to Friendly Captcha.
     this.send(msg);
   }
 


### PR DESCRIPTION
I haven't seen an instance where this caused issues, but there is nothing stopping different plugins/tabs/code from sending `undefined` or `null`: this will make sure we don't throw an exception then.