### PR TITLE
No longer debug print messages received from different origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.14
+
+* Removed debug message printed to console when a message was ignored from a non-Friendly Captcha iframe source.
+
 ## 0.1.13
 
 * Remove patching of `Promise.prototype.constructor` to avoid issues with Angular and other libraries that extend or overwrite `Promise`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "In-browser SDK for Friendly Captcha v2 (currently in preview only)",
   "main": "dist/sdk.js",
   "type": "module",

--- a/src/communication/bus.ts
+++ b/src/communication/bus.ts
@@ -114,8 +114,8 @@ export class CommunicationBus {
   private onReceive(ev: MessageEvent) {
     if (!isAllowedOrigin(ev.origin, this.origins)) {
       // This may be an attempt at abuse or it's simply another iframe sending messages.
-      // We silently ignore the message. For dev purposes we currently print a debug message.
-      console.debug("Friendly Captcha communication bus ignored message from origin " + ev.origin, this.origins);
+      // We silently ignore the message. For dev purposes we can print a debug message.
+      // console.debug("Friendly Captcha communication bus ignored message from origin " + ev.origin, this.origins);
       return;
     }
 


### PR DESCRIPTION
In some setups this was causing a rather obnoxious amount of spam in the console.