### PR TITLE
Allow disabling eval patching

### DIFF
--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -138,6 +138,7 @@ export class FriendlyCaptchaSDK {
 // @public
 export interface FriendlyCaptchaSDKOptions {
     apiEndpoint?: string | "eu" | "global";
+    disableEvalPatching?: boolean;
     startAgent?: boolean;
 }
 

--- a/src/sdk/endpoint.ts
+++ b/src/sdk/endpoint.ts
@@ -9,28 +9,6 @@ const SHORTHANDS: Record<string, string> = {
   global: "https://global.frcapi.com/api/v2/captcha",
 };
 
-export function getSDKAPIEndpoint(): string | undefined {
-  // 1. We check for the meta tag `frc-api-endpoint`
-  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-api-endpoint"]`);
-  if (m) return m.content;
-
-  // 2. We check the current script element for `data-frc-api-endpoint`.
-  const cs = document.currentScript;
-  if (cs) {
-    const endpoint = cs.dataset["frcApiEndpoint"];
-    if (endpoint) return endpoint;
-  }
-
-  // 3. We search for widgets that specify `data-api-endpoint`.
-  const we = document.querySelector(".frc-captcha[data-api-endpoint]") as HTMLElement;
-  if (we) {
-    const endpoint = we.dataset["apiEndpoint"];
-    if (endpoint) return endpoint;
-  }
-
-  return undefined;
-}
-
 export function resolveAPIEndpoint(optionValue: string | undefined) {
   if (!optionValue) {
     // We default to the global endpoint

--- a/src/sdk/options.ts
+++ b/src/sdk/options.ts
@@ -3,7 +3,7 @@ export function getSDKDisableEvalPatching(): boolean {
   const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-disable-eval-patching"]`);
   if (!m) return false;
 
-  return m.content === "true";
+  return !!m.content;
 }
 
 export function getSDKAPIEndpoint(): string | undefined {

--- a/src/sdk/options.ts
+++ b/src/sdk/options.ts
@@ -1,0 +1,27 @@
+export function getSDKDisableEvalPatching(): boolean {
+  // We check if the meta tag `frc-disable-eval-patching` is present.
+  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-disable-eval-patching"]`);
+  return m !== null;
+}
+
+export function getSDKAPIEndpoint(): string | undefined {
+  // 1. We check for the meta tag `frc-api-endpoint`
+  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-api-endpoint"]`);
+  if (m) return m.content;
+
+  // 2. We check the current script element for `data-frc-api-endpoint`.
+  const cs = document.currentScript;
+  if (cs) {
+    const endpoint = cs.dataset["frcApiEndpoint"];
+    if (endpoint) return endpoint;
+  }
+
+  // 3. We search for widgets that specify `data-api-endpoint`.
+  const we = document.querySelector(".frc-captcha[data-api-endpoint]") as HTMLElement;
+  if (we) {
+    const endpoint = we.dataset["apiEndpoint"];
+    if (endpoint) return endpoint;
+  }
+
+  return undefined;
+}

--- a/src/sdk/options.ts
+++ b/src/sdk/options.ts
@@ -1,7 +1,9 @@
 export function getSDKDisableEvalPatching(): boolean {
   // We check if the meta tag `frc-disable-eval-patching` is present.
   const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-disable-eval-patching"]`);
-  return m !== null;
+  if (!m) return false;
+
+  return m.content === "true";
 }
 
 export function getSDKAPIEndpoint(): string | undefined {

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -21,10 +21,11 @@ import { flatPromise } from "../util/flatPromise.js";
 import { WidgetHandle } from "./widgetHandle.js";
 import { Store } from "./persist.js";
 import { Signals, getSignals } from "../signals/collect.js";
-import { getSDKAPIEndpoint, resolveAPIEndpoint } from "./endpoint.js";
+import { resolveAPIEndpoint } from "./endpoint.js";
 import { stringHasPrefix } from "../util/string.js";
 import { mergeObject } from "../util/object.js";
 import { _RootTrigger } from "../types/trigger.js";
+import { getSDKAPIEndpoint, getSDKDisableEvalPatching } from "./options.js";
 
 const agentEndpoint = "/agent";
 const widgetEndpoint = "/widget";
@@ -55,6 +56,11 @@ export interface FriendlyCaptchaSDKOptions {
    * - `global` - `https://global.frcapi.com/api/v2/captcha`
    */
   apiEndpoint?: string | "eu" | "global";
+
+  /**
+   * Whether to disable the eval patching. Useful when the patching breaks your site.
+   */
+  disableEvalPatching?: boolean;
 }
 
 /**
@@ -112,7 +118,7 @@ export class FriendlyCaptchaSDK {
   /**
    * @internal
    */
-  private signals: Signals = getSignals();
+  private signals: Signals;
 
   constructor(opts: FriendlyCaptchaSDKOptions = {}) {
     this.baseURL = resolveAPIEndpoint(opts.apiEndpoint || getSDKAPIEndpoint());
@@ -128,6 +134,10 @@ export class FriendlyCaptchaSDK {
         "Multiple Friendly Captcha SDKs created, this is not recommended. Please use a single SDK instance.",
       );
     }
+
+    this.signals = getSignals({
+      disableEvalPatching: opts.disableEvalPatching || getSDKDisableEvalPatching(),
+    });
 
     if (opts.startAgent !== false) {
       this.ensureAgentIFrame();

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -58,7 +58,8 @@ export interface FriendlyCaptchaSDKOptions {
   apiEndpoint?: string | "eu" | "global";
 
   /**
-   * Whether to disable the eval patching. Useful when the patching breaks your site.
+   * Whether to disable the patching of `window.eval`. Useful when the patching breaks your site, which in particular
+   * may affect some hot reloading functionality for Webpack (in `dev` mode).
    */
   disableEvalPatching?: boolean;
 }

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -240,7 +240,7 @@ export class Signals {
       do: this.setupOrientationMetrics(),
     };
 
-    this.takeTraceRecords = patchNativeFunctions(opts.disableEvalPatching);
+    this.takeTraceRecords = patchNativeFunctions(opts);
   }
 
   private setupMovementMetrics(): {
@@ -528,6 +528,6 @@ export class Signals {
  * Returns the global signals object.
  * @internal
  */
-export function getSignals(opts: SignalsOptions = {}) {
+export function getSignals(opts: SignalsOptions) {
   return ssig || (ssig = new Signals(opts));
 }

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -154,6 +154,9 @@ export class Signals {
   private rn: number = 0;
   private bh: BehaviorSignal;
 
+  // Whether patching of window.eval is disabled.
+  private dep: boolean;
+
   /** Counter */
   private i = 0;
 
@@ -240,6 +243,7 @@ export class Signals {
       do: this.setupOrientationMetrics(),
     };
 
+    this.dep = opts.disableEvalPatching || false;
     this.takeTraceRecords = patchNativeFunctions(opts);
   }
 
@@ -488,6 +492,7 @@ export class Signals {
       i: ++this.i,
       hl: history.length,
       fe: !!window.frameElement,
+      dep: this.dep,
       wid: widgetId,
       sc: parseInt(sessionCount(false)),
       sid: sessionId(),

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -165,7 +165,7 @@ export class Signals {
 
   private takeTraceRecords: () => RootTraceRecord[];
 
-  constructor(opts: SignalsOptions = {}) {
+  constructor(opts: SignalsOptions) {
     const $: "mouse" = "mouse";
 
     // Set up mouse enter leave signals

--- a/src/signals/collectStacktrace.ts
+++ b/src/signals/collectStacktrace.ts
@@ -93,13 +93,16 @@ export const patchNativeFunctions = function (disableEvalPatching: boolean = fal
     ["Element." + p + ".shadowRoot", w.Element[p], "shadowRoot"],
     ["Node." + p + ".nodeType", w.Node[p], "nodeType"],
     // Values holding functions
-    ["eval", w, "eval"],
     ["Object.is", w.Object, "is"],
     ["Array." + p + ".slice", w.Array[p], "slice"],
     ["Document." + p + ".querySelectorAll", w.Document[p], "querySelectorAll"],
     ["Document." + p + ".createElement", w.Document[p], "createElement"],
     ["EventTarget." + p + ".dispatchEvent", dispatchEvent, "dispatchEvent"],
   ];
+
+  if (!disableEvalPatching) {
+    patches.push(["eval", w, "eval"]);
+  }
 
   patches.forEach(function ([name, target, prop]) {
     const descriptor = Object.getOwnPropertyDescriptor(target, prop);

--- a/src/signals/collectStacktrace.ts
+++ b/src/signals/collectStacktrace.ts
@@ -29,7 +29,7 @@ const isFunc = function (value: unknown): value is Function {
 /**
  * Defensively patch native functions to capture stack traces.
  */
-export const takeRecords = (function () {
+export const patchNativeFunctions = function (disableEvalPatching: boolean = false) {
   const queue: RootTraceRecord[] = [];
 
   /** Used for deeply patching toString. The Map implementation is necessary */
@@ -160,4 +160,4 @@ export const takeRecords = (function () {
   });
 
   return takeRecords;
-})();
+};

--- a/src/signals/collectStacktrace.ts
+++ b/src/signals/collectStacktrace.ts
@@ -29,7 +29,7 @@ const isFunc = function (value: unknown): value is Function {
 /**
  * Defensively patch native functions to capture stack traces.
  */
-export const patchNativeFunctions = function (disableEvalPatching: boolean = false) {
+export const patchNativeFunctions = function (opts: { disableEvalPatching?: boolean }) {
   const queue: RootTraceRecord[] = [];
 
   /** Used for deeply patching toString. The Map implementation is necessary */
@@ -100,7 +100,7 @@ export const patchNativeFunctions = function (disableEvalPatching: boolean = fal
     ["EventTarget." + p + ".dispatchEvent", dispatchEvent, "dispatchEvent"],
   ];
 
-  if (!disableEvalPatching) {
+  if (!opts.disableEvalPatching) {
     patches.push(["eval", w, "eval"]);
   }
 

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -43,6 +43,11 @@ export type RootSignalsV1Raw<MetricVectorType = OnlineMetricStateVector> = {
    */
   fe: boolean;
 
+  /**
+   * Whether patching of window.eval is disabled.
+   */
+  dep: boolean;
+
   sid: string;
   sc: number;
 


### PR DESCRIPTION
This adds an option to `FriendlyCaptchaSDK` that allows users to disable the patching of `window.eval` which happens to break some websites. Users that use the `site.js` version can create a `frc-disable-eval-patching` meta tag similar to the `frc-api-endpoint` meta tag for configuring the API endpoint.

To make this possible we had to defer the patching until the SDK is created. I believe this is fine because we tell users to create one global SDK instance.

We considered two other options for the configuration in the `site.js` version:
- Putting in the query URL (`<script src="site.js?disableEvalPatching=1">`), the downside is that users would have to put it on both the compat and non-compat script tag.
- Putting data attributes on the script tags (`script data-disable-eval-patching="1" src="site.js" />`), same downside as above and in the module version `import.meta´ doesn't expose the dataset of the script element directly.