### PR TITLE
Fix handling of `apiEndpoint` in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.17
+
+* Fixed a regression that broken configuring widget API endpoints in the SDK constructor.
+
 ## 0.1.16
 
 * Fixed a bug that sometimes caused widget timeout errors when using the `eu` API endpoint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@friendlycaptcha/sdk",
   "version": "0.1.16",
-  "description": "In-browser SDK for Friendly Captcha v2 (currently in preview only)",
+  "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "type": "module",
   "private": true,

--- a/sdktest/test/api_endpoint_prioritization_order/body.tmpl.html
+++ b/sdktest/test/api_endpoint_prioritization_order/body.tmpl.html
@@ -1,0 +1,12 @@
+<main>
+    <form>
+        <input type="textarea" />
+        <div id="create-widget-option"></div>
+        <div id="sdk-option"></div>
+        <div class="frc-captcha" data-sitekey="{{ .Config.Sitekey }}" data-api-endpoint="{{ .Config.APIEndpoint }}">
+        </div>
+        <input type="submit" />
+    </form>
+</main>
+
+<script defer src="main.tmpl.ts"></script>

--- a/sdktest/test/api_endpoint_prioritization_order/config.yaml
+++ b/sdktest/test/api_endpoint_prioritization_order/config.yaml
@@ -1,0 +1,1 @@
+api_endpoint: https://data-api-endpoint.frcapi.com

--- a/sdktest/test/api_endpoint_prioritization_order/main.tmpl.ts
+++ b/sdktest/test/api_endpoint_prioritization_order/main.tmpl.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { FriendlyCaptchaSDK } from "../../../dist/sdk.js";
+import { sdktest } from "../../sdktestlib/sdk.js";
+
+sdktest.description(
+  "Create 3 widgets, configuring the API endpoint in 3 different ways, and ensure that the configuration prioritization is correct."
+);
+
+const sitekey = "{{.Config.Sitekey}}";
+
+const datasetAPIEndpoint = "{{.Config.APIEndpoint}}";
+const widgetOptionEndpoint = "https://create-widget-opts.frcapi.com";
+const sdkOptionEndpoint = "https://create-sdk-opts.frcapi.com";
+
+// Configure the SDK with an API endpoint.
+const sdk = new FriendlyCaptchaSDK({ apiEndpoint: sdkOptionEndpoint });
+
+// Should mount a new widget to the div with class `frc-captcha`.
+// This widget should be configured via its `data-api-endpoint` HTML attribute.
+sdk.attach();
+
+// This widget's endpoint is manually configured with an `apiEndpoint`.
+const manuallyConfiguredWidget = sdk.createWidget({
+  element: document.getElementById("create-widget-option"),
+  sitekey,
+  apiEndpoint: widgetOptionEndpoint,
+});
+
+// This widget should get its `apiEndpoint` via the configuration based to the
+// SDK constructor.
+const sdkConfiguredWidget = sdk.createWidget({
+  element: document.getElementById("sdk-option"),
+  sitekey,
+});
+
+// Returns true if an agent iframe exists with the given endpoint in its `src` attribute.
+function agentWithSrcExists(endpoint: string) {
+  const iframes = document.querySelectorAll(".frc-i-agent");
+  for (const i of iframes) {
+    if (i.getAttribute("src")?.includes(endpoint)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns true if a widget iframe (corresponding to the passed widget id)
+// exists and has the given endpoint in its `src` attribute.
+function widgetIFrameHasCorrectSrc(id: string, endpoint: string) {
+  const iframe = document.querySelector(`[data--frc-frame-id="${id}"]`);
+  return iframe?.getAttribute("src")?.includes(endpoint);
+}
+
+sdktest.test({ name: "three widgets present" }, async (t) => {
+  t.require.numberOfWidgets(3);
+});
+
+// For each of the 3 widgets, which have been configured with an API endpoint in a different way,
+// make sure that the expected widget iframe has the correct endpoint *and* that there is
+// an agent iframe for that endpoint.
+sdktest.test({ name: "iframes exist for widgets with each configured endpoint" }, async (t) => {
+  const attachedWidget = t.getWidget();
+  t.assert.truthy(agentWithSrcExists(datasetAPIEndpoint), `missing agent iframe for ${datasetAPIEndpoint}`);
+  t.assert.truthy(
+    widgetIFrameHasCorrectSrc(attachedWidget.id, datasetAPIEndpoint),
+    `data-attr-configured widget with id ${attachedWidget.id} does not have an iframe with src of ${datasetAPIEndpoint}`,
+  );
+
+  t.assert.truthy(agentWithSrcExists(widgetOptionEndpoint), `missing agent iframe for ${widgetOptionEndpoint}`);
+  t.assert.truthy(
+    widgetIFrameHasCorrectSrc(manuallyConfiguredWidget.id, widgetOptionEndpoint),
+    `widget-options-configured widget with id ${manuallyConfiguredWidget.id} does not have an iframe with src of ${widgetOptionEndpoint}`,
+  );
+
+  t.assert.truthy(agentWithSrcExists(sdkOptionEndpoint), `missing agent iframe for ${sdkOptionEndpoint}`);
+  t.assert.truthy(
+    widgetIFrameHasCorrectSrc(sdkConfiguredWidget.id, sdkOptionEndpoint),
+    `sdk-options-configured widget with id ${sdkConfiguredWidget.id} does not have an iframe with src of ${sdkOptionEndpoint}`,
+  );
+});

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -56,6 +56,14 @@ export type WidgetMode = "interactive" | "noninteractive";
 export type WidgetResetTrigger = "widget" | "root" | "agent";
 
 /**
+ * Which API endpoint to use for the SDK. Typically "eu" or "global", but a URL can be used to specify a custom endpoint.
+ * Defaults to "global".
+ *
+ * @public
+ */
+export type APIEndpoint = string | "eu" | "global";
+
+/**
  * @internal
  */
 export interface WidgetProgress {
@@ -139,7 +147,7 @@ export interface CreateWidgetOptions {
   /**
    * A custom endpoint from which the agent and widgets are loaded.
    */
-  apiEndpoint?: string | "eu" | "global";
+  apiEndpoint?: APIEndpoint;
 
   /**
    * Language code such as "en" for English or "de" for German.


### PR DESCRIPTION
We need to keep track of whether an `apiEndpoint` was passed to the `FriendlyCaptchaSDK` constructor. And then check it when creating widgets. The order of priority for determining a widget's `apiEndpoint` should be

1. `CreateWidgetOptions`
2. `data-api-endpoint`
3. `FriendlyCaptchaSDKOptions`
4. `getSDKAPIEndpoint()`