### PR TITLE
Defer DOM event listener creation until DOM is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.18
+
+* Defer initialization of `document.body` event listeners until DOM is ready.
+
 ## 0.1.17
 
 * Fixed a regression that broken configuring widget API endpoints in the SDK constructor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "type": "module",

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -46,13 +46,14 @@ function onOffEventMetric(
   onEventName: string,
   offEventName: string,
   retrigger: boolean = false,
-  target: HTMLElement | Document = document.body,
+  target?: HTMLElement | Document,
 ): OnlineMetricStateVector {
   const m = buildOnlineMetric();
   let on = false; // Current state
   let ts: number;
 
   ol(() => {
+    target = target || document.body;
     target[x](onEventName, (ev) => {
       if (!on || retrigger) {
         ts = ev.timeStamp;

--- a/src/signals/collect.ts
+++ b/src/signals/collect.ts
@@ -274,7 +274,6 @@ export class Signals {
       ns: 0,
     };
 
-    const b = document.body;
     const updateFunc = () => {
       const lastSample = sample[sample.length - 1];
 
@@ -331,30 +330,33 @@ export class Signals {
       }
     };
 
-    ol(() => b[x]("mousemove", (e) => {
-      this.mm = e;
-      if (intervalHandle === undefined) {
-        updateFunc();
-        intervalHandle = setInterval(updateFunc, interval);
-      }
-    }));
-
     let lastRadius = -1;
-    ol(() => b[x]("touchmove", (e) => {
-      this.tm = e;
-      const t = e.touches[0];
-      if (t) {
-        const newRadius = t.radiusX + t.radiusY * 1.234; // Poor man's hash
-        if (newRadius !== lastRadius) {
-          lastRadius = newRadius;
-          this.rn++;
+    ol(() => {
+      const b = document.body;
+      b[x]("mousemove", (e) => {
+        this.mm = e;
+        if (intervalHandle === undefined) {
+          updateFunc();
+          intervalHandle = setInterval(updateFunc, interval);
         }
-      }
-      if (intervalHandle === undefined) {
-        updateFunc();
-        intervalHandle = setInterval(updateFunc, interval);
-      }
-    }));
+      });
+
+      b[x]("touchmove", (e) => {
+        this.tm = e;
+        const t = e.touches[0];
+        if (t) {
+          const newRadius = t.radiusX + t.radiusY * 1.234; // Poor man's hash
+          if (newRadius !== lastRadius) {
+            lastRadius = newRadius;
+            this.rn++;
+          }
+        }
+        if (intervalHandle === undefined) {
+          updateFunc();
+          intervalHandle = setInterval(updateFunc, interval);
+        }
+      });
+    });
 
     return out;
   }


### PR DESCRIPTION
When an instance `FriendlyCaptchaSDK` is created, it sets up some event listeners, including on `document.body`. Depending on where instantiation happens, `document.body` might not yet be defined, so this PR moves the setup of those listeners into a callback that runs when the `document.body` is available.