### PR TITLE
Add `title` attribute to widget iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.20
+
+* Add a `title` attribute to the widget iframe for accessibility.
+
 ## 0.1.19
 
 * Make agent and widget iframe retry timeouts exponential

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "type": "module",

--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -86,6 +86,7 @@ export function createWidgetIFrame(
 
   el.src = widgetUrl + "?" + encodeQuery(frameData);
   el.className = WIDGET_FRAME_CLASSNAME;
+  el.title = getLocalizedWidgetTitle(language);
   el.dataset[FRAME_ID_DATASET_FIELD] = widgetId;
   const s = el.style;
   s.border = s.visibility = "0";
@@ -97,6 +98,29 @@ export function createWidgetIFrame(
   // Note: we must use `appendChild` instead of `append` for IE11.
   opts.element.appendChild(el);
   return el;
+}
+
+const WIDGET_TITLE_LOCALIZATIONS: Record<string, string> = {
+  cs: "Ověření proti botům",
+  da: "Anti-robot verificering",
+  nl: "Anti-robotverificatie",
+  en: "Anti-Robot verification",
+  fr: "Vérification Anti-Robot",
+  de: "Anti-Roboter-Verifizierung",
+  hu: "Anti-Robot ellenőrzés",
+  it: "Verifica anti-robot",
+  pl: "Weryfikacja antybotowa",
+  pt: "Verificação Anti-Robô",
+  ru: "Проверка на Анти-Робота",
+  es: "Verificación anti-robot",
+  sv: "Anti-Robot Verifiering",
+  tr: "Anti-Robot doğrulaması",
+}
+
+function getLocalizedWidgetTitle(lang: string): string {
+  lang = lang.toLowerCase().split("-")[0].split("_")[0];
+  const name = WIDGET_TITLE_LOCALIZATIONS[lang] || WIDGET_TITLE_LOCALIZATIONS["en"];
+  return name + " - Widget";
 }
 
 /**


### PR DESCRIPTION
Per WCAG 2.0, iframe elements must have accessible names. Those names come from the `title` attribute.

https://www.w3.org/TR/WCAG20-TECHS/H64.html