### PR TITLE
Un-escape markdown links when rewriting for docusaurus

### DIFF
--- a/docudocs.mjs
+++ b/docudocs.mjs
@@ -67,6 +67,13 @@ async function main() {
         if (line.startsWith("|")) {
           line = line.replace(/\\\|/g, "&#124;");
         }
+
+        // api-documenter escapes markdown links, so we need to unescape them
+        // to display them correctly in docusaurus.
+        if (line.match(/\\\[(.*?)\\\]\((.*?)\)/)) {
+          line = line.replace(/\\\[(.*?)\\\]\((.*?)\)/, "[$1]($2)");
+        }
+
         if (!skip) {
           output.push(line);
         }


### PR DESCRIPTION
`api-documenter` seems to escape markdown links in doc comments. This means when we embed the generated SDK docs in the developer documentation site the the widget lifecycle links don't work. To fix this, when translating the docs for docusaurus, unescape the links.