### PR TITLE
Increase retry timeout

### DIFF
--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -289,7 +289,8 @@ export class FriendlyCaptchaSDK {
    * @internal
    */
   private getRetryTimeout(retryLoadCounter: number) {
-    return Math.pow(retryLoadCounter, 1.8) * 1000 + 2000;
+    // 1st timeout = 5 secs, 5th timeout = 29 secs, sum of all timeouts = 75 secs
+    return Math.pow(retryLoadCounter, 2) * 1000 + 4000;
   }
 
   /**


### PR DESCRIPTION
Previously the progression looked like this:

- 1st timeout = 3s
- 2nd timeout = 4.3s
- 3rd timeout = 10.5s
- 4th timeout = 14.6s
- 5th timeout = 19.4s
- Total of all timeouts = 52s

Now the progression looks like this:

- 1st timeout = 5s
- 2nd timeout = 8s
- 3rd timeout = 13s
- 4th timeout = 20s
- 5th timeout = 29s
- Total of all timeouts = 75s

I don't think increasing the max number of retries has much benefit.

I _am_ wondering about user experience though in those cases where we want the first retry to be faster? But I guess 5 seconds isn't _that_ much different from 3 seconds, which is already quite a noticeably long period for interactive websites.