### PR TITLE
Correctly position banner for RTL languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.25
+
+* Correctly position the banner for right-to-left languages.
+
 ## 0.1.24
 
 * Localize iframe title when the widget language changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "type": "module",

--- a/sdktest/test/rtl_language/body.tmpl.html
+++ b/sdktest/test/rtl_language/body.tmpl.html
@@ -1,0 +1,20 @@
+<main>
+    <form>
+        <input type="textarea" />
+        <div class="programmatic-mount"></div>
+
+        Widget in right-to-left HTML language (Arabic)
+        <div class="frc-captcha" data-sitekey="{{ .Config.Sitekey }}" data-lang="ar"></div>
+
+        Widget with explicitly specified right-to-left language ("ar")
+        <div class="frc-captcha" data-sitekey="{{ .Config.Sitekey }}" data-lang="ar"></div>
+
+        Widget with explicitly specified left-to-right language ("en")
+        <div class="frc-captcha" data-sitekey="{{ .Config.Sitekey }}" data-lang="en"></div>
+
+    </form>
+</main>
+
+<script defer src=" {{ .SiteJSPath }}">
+</script>
+<script defer src="main.tmpl.ts"></script>

--- a/sdktest/test/rtl_language/config.yaml
+++ b/sdktest/test/rtl_language/config.yaml
@@ -1,0 +1,1 @@
+language: "ar"

--- a/sdktest/test/rtl_language/main.tmpl.ts
+++ b/sdktest/test/rtl_language/main.tmpl.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2025.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { sdktest } from "../../sdktestlib/sdk.js";
+
+sdktest.description("Purely visual check: the widget layout direction should match what the language specifies.");

--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -57,10 +57,7 @@ export function createWidgetIFrame(
 ): HTMLIFrameElement {
   const el = document.createElement("iframe");
 
-  let language = opts.language;
-  if (!language || language === "html") {
-    language = findFirstParentLangAttribute(opts.element) || "";
-  }
+  const language = getLanguageFromOptionsOrParent(opts);
 
   const frameData: FrameParams = {
     origin: document.location.origin,
@@ -117,10 +114,22 @@ const WIDGET_TITLE_LOCALIZATIONS: Record<string, string> = {
   tr: "Anti-Robot doğrulaması",
 };
 
+// Languages that require a right-to-left layout.
+const RTL_LANGUAGES = ["ar", "he", "fa", "ur", "ps", "sd", "yi"];
+
+function getLanguageCode(lang: string): string {
+  return lang.toLowerCase().split("-")[0].split("_")[0];
+}
+
 export function getLocalizedWidgetTitle(lang: string): string {
-  lang = lang.toLowerCase().split("-")[0].split("_")[0];
+  lang = getLanguageCode(lang);
   const name = WIDGET_TITLE_LOCALIZATIONS[lang] || WIDGET_TITLE_LOCALIZATIONS["en"];
   return name + " - Widget";
+}
+
+export function isRTLLanguage(lang: string): boolean {
+  lang = getLanguageCode(lang);
+  return RTL_LANGUAGES.includes(lang);
 }
 
 /**
@@ -168,10 +177,16 @@ export function createBanner(opts: CreateWidgetOptions) {
   const el = document.createElement("div");
   el.classList.add("frc-banner");
 
+  const language = getLanguageFromOptionsOrParent(opts);
+
   const els = el.style;
   els.position = "absolute";
   els.bottom = "2px";
-  els.right = "6px";
+  if (isRTLLanguage(language)) {
+    els.left = "6px";
+  } else {
+    els.right = "6px";
+  }
   els.lineHeight = "1";
 
   const a = document.createElement("a");
@@ -204,4 +219,12 @@ export function createBanner(opts: CreateWidgetOptions) {
   el.appendChild(a);
 
   opts.element.appendChild(el);
+}
+
+function getLanguageFromOptionsOrParent(opts: CreateWidgetOptions): string {
+  let language = opts.language;
+  if (!language || language === "html") {
+    language = findFirstParentLangAttribute(opts.element) || "";
+  }
+  return language;
 }

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -15,6 +15,7 @@ import {
   AGENT_FRAME_CLASSNAME,
   createWidgetPlaceholder,
   getLocalizedWidgetTitle,
+  isRTLLanguage,
 } from "./create.js";
 import {
   EnvelopedMessage,
@@ -198,6 +199,18 @@ export class FriendlyCaptchaSDK {
 
     if (iframe) {
       iframe.title = getLocalizedWidgetTitle(msg.language);
+    }
+
+    const banner = element.querySelector(".frc-banner") as HTMLElement;
+    if (banner) {
+      const bs = banner.style;
+      if (isRTLLanguage(msg.language)) {
+        bs.left = "6px";
+        bs.right = "auto";
+      } else {
+        bs.left = "auto";
+        bs.right = "6px";
+      }
     }
   }
 


### PR DESCRIPTION
This PR correctly positions the banner to the left for RTL languages. Other widget elements are handled by the content that is server from the API.

### Preview

<img width="490" alt="Screenshot 2025-07-09 at 20 04 41" src="https://github.com/user-attachments/assets/f26d9bd8-0ef8-4e82-8934-427384c512b1" />
