### PR TITLE
Fix RTL language rendering for older browsers

### DIFF
--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -129,7 +129,7 @@ export function getLocalizedWidgetTitle(lang: string): string {
 
 export function isRTLLanguage(lang: string): boolean {
   lang = getLanguageCode(lang);
-  return RTL_LANGUAGES.includes(lang);
+  return RTL_LANGUAGES.indexOf(lang) !== -1;
 }
 
 /**


### PR DESCRIPTION
This PR fixes the rendering since older browsers that we support don't have `Array.prototype.includes`.