### PR TITLE
Encode sentinel debug data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## Unreleased
+
+* Encode debug information in the response in case the user agent can not connect to Friendly Captcha at all.
+
 ## 0.1.30
 
 * Add a specific error code that represents the widget being unreachable.

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -7,7 +7,7 @@
 import { StartMode, APIEndpoint, CreateWidgetOptions } from "../types/widget.js";
 import { CommunicationBus } from "../communication/bus.js";
 import { randomId } from "../util/random.js";
-import { encodeQuery, originOf } from "../util/url.js";
+import { originOf } from "../util/url.js";
 import {
   createBanner,
   createAgentIFrame,
@@ -41,7 +41,7 @@ import { _RootTrigger } from "../types/trigger.js";
 import { resolveAPIOrigin, getSDKAPIEndpoint, getSDKDisableEvalPatching } from "./options.js";
 import { SentinelResponseDebugData } from "../types/sentinel.js";
 import { tz } from "../util/tz.js";
-import { encodeBase64Url, encodeStringToBase64Url } from "../util/encode.js";
+import { encodeStringToBase64Url } from "../util/encode.js";
 
 declare const SDK_VERSION: string;
 
@@ -444,14 +444,14 @@ export class FriendlyCaptchaSDK {
     let retryLoadCounter = 1;
 
     function setUnreachableState(detail: string) {
-      const debugString= encodeStringToBase64Url(encodeQuery({
+      const debugString= encodeStringToBase64Url(JSON.stringify({
         sdk_v: SDK_VERSION,
         sitekey: opts.sitekey || "",
         retry: retryLoadCounter + "",
         endpoint: origin,
         ua: navigator.userAgent,
         tz: tz(),
-      }));
+      } as SentinelResponseDebugData));
 
       let resp = ".ERROR.UNREACHABLE";
       if (debugString) {

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -26,11 +26,7 @@ import {
   ToRootMessage,
   WidgetLanguageChangeMessage,
 } from "../types/messages.js";
-import {
-  findCaptchaElements,
-  removeWidgetRootStyles,
-  setWidgetRootStyles,
-} from "./dom.js";
+import { findCaptchaElements, removeWidgetRootStyles, setWidgetRootStyles } from "./dom.js";
 import { flatPromise } from "../util/flatPromise.js";
 import { WidgetHandle } from "./widgetHandle.js";
 import { Store } from "./persist.js";
@@ -444,14 +440,16 @@ export class FriendlyCaptchaSDK {
     let retryLoadCounter = 1;
 
     function setUnreachableState(detail: string) {
-      const debugString= encodeStringToBase64Url(JSON.stringify({
-        sdk_v: SDK_VERSION,
-        sitekey: opts.sitekey || "",
-        retry: retryLoadCounter + "",
-        endpoint: origin,
-        ua: navigator.userAgent,
-        tz: tz(),
-      } as SentinelResponseDebugData));
+      const debugString = encodeStringToBase64Url(
+        JSON.stringify({
+          sdk_v: SDK_VERSION,
+          sitekey: opts.sitekey || "",
+          retry: retryLoadCounter + "",
+          endpoint: origin,
+          ua: navigator.userAgent,
+          tz: tz(),
+        } as SentinelResponseDebugData),
+      );
 
       let resp = ".ERROR.UNREACHABLE";
       if (debugString) {

--- a/src/types/sentinel.ts
+++ b/src/types/sentinel.ts
@@ -22,3 +22,18 @@ export type SentinelResponse =
   | ".ERROR"
   | ".ERROR.UNREACHABLE"
   | ".RESET";
+
+  /**
+   * Sentinel Response Debug Data
+   * 
+   * @private
+   */
+export interface SentinelResponseDebugData {
+  sdk_v: string
+  sitekey: string;
+  retry: string;
+  endpoint: string;
+
+  ua: string;
+  tz: string;
+}

--- a/src/util/encode.ts
+++ b/src/util/encode.ts
@@ -10,12 +10,12 @@ const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
  * Encodes a string to Base64 URL format. If TextEncoder is not available, returns an empty string.
  * @param str {string} The string to encode.
  * @return {string} The Base64 URL encoded string, or an empty string if TextEncoder is not available.
- * 
+ *
  * @private
  */
 export function encodeStringToBase64Url(str: string): string {
   if (!window.TextEncoder) {
-    return ""
+    return "";
   }
   return encodeBase64Url(new TextEncoder().encode(str));
 }
@@ -24,7 +24,7 @@ export function encodeStringToBase64Url(str: string): string {
  * Encodes a Uint8Array to Base64 URL format.
  * @param bytes {Uint8Array} The byte array to encode.
  * @returns {string} The Base64 URL encoded string.
- * 
+ *
  * @private
  */
 export function encodeBase64Url(bytes: Uint8Array): string {

--- a/src/util/encode.ts
+++ b/src/util/encode.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/**
+ * Encodes a string to Base64 URL format. If TextEncoder is not available, returns an empty string.
+ * @param str {string} The string to encode.
+ * @return {string} The Base64 URL encoded string, or an empty string if TextEncoder is not available.
+ * 
+ * @private
+ */
+export function encodeStringToBase64Url(str: string): string {
+  if (!window.TextEncoder) {
+    return ""
+  }
+  return encodeBase64Url(new TextEncoder().encode(str));
+}
+
+/**
+ * Encodes a Uint8Array to Base64 URL format.
+ * @param bytes {Uint8Array} The byte array to encode.
+ * @returns {string} The Base64 URL encoded string.
+ * 
+ * @private
+ */
+export function encodeBase64Url(bytes: Uint8Array): string {
+  const len = bytes.length;
+  let base64 = "";
+
+  for (let i = 0; i < len; i += 3) {
+    const b0 = bytes[i + 0];
+    const b1 = bytes[i + 1];
+    const b2 = bytes[i + 2];
+    // This temporary variable stops the NextJS 13 compiler from breaking this code in optimization.
+    // See issue https://github.com/FriendlyCaptcha/friendly-challenge/issues/165
+    let t = "";
+    t += CHARS.charAt(b0 >>> 2);
+    t += CHARS.charAt(((b0 & 3) << 4) | (b1 >>> 4));
+    t += CHARS.charAt(((b1 & 15) << 2) | (b2 >>> 6));
+    t += CHARS.charAt(b2 & 63);
+    base64 += t;
+  }
+
+  if (len % 3 === 2) {
+    base64 = base64.substring(0, base64.length - 1) + "=";
+  } else if (len % 3 === 1) {
+    base64 = base64.substring(0, base64.length - 2) + "==";
+  }
+
+  return base64;
+}

--- a/src/util/tz.ts
+++ b/src/util/tz.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Returns time zone name on a best-effort basis.
+ * 
+ * @private
+ */
+export function tz(): string {
+    const intl = window.Intl;
+    if (!intl || !intl.DateTimeFormat) {
+        return "";
+    }
+    const dtf = new intl.DateTimeFormat();
+    if (!dtf || !dtf.resolvedOptions) {
+        return "";
+    }
+
+    return dtf.resolvedOptions().timeZone;
+}

--- a/src/util/tz.ts
+++ b/src/util/tz.ts
@@ -7,18 +7,18 @@
 
 /**
  * Returns time zone name on a best-effort basis.
- * 
+ *
  * @private
  */
 export function tz(): string {
-    const intl = window.Intl;
-    if (!intl || !intl.DateTimeFormat) {
-        return "";
-    }
-    const dtf = new intl.DateTimeFormat();
-    if (!dtf || !dtf.resolvedOptions) {
-        return "";
-    }
+  const intl = window.Intl;
+  if (!intl || !intl.DateTimeFormat) {
+    return "";
+  }
+  const dtf = new intl.DateTimeFormat();
+  if (!dtf || !dtf.resolvedOptions) {
+    return "";
+  }
 
-    return dtf.resolvedOptions().timeZone;
+  return dtf.resolvedOptions().timeZone;
 }

--- a/test/util/encode.test.ts
+++ b/test/util/encode.test.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import test from "ava";
+import { encodeStringToBase64Url } from "../../src/util/encode.js";
+
+test("encodes string to base64url correctly", (t) => {
+  // Hack to ensure the global `window` object is available for the test.
+  (globalThis as any).window = globalThis;
+
+  const inputString = "Hello, World!";
+  const expectedOutput = "SGVsbG8sIFdvcmxkIQ==";
+
+    const encodedString = encodeStringToBase64Url(inputString);
+    t.is(encodedString, expectedOutput);
+});

--- a/test/util/encode.test.ts
+++ b/test/util/encode.test.ts
@@ -14,6 +14,6 @@ test("encodes string to base64url correctly", (t) => {
   const inputString = "Hello, World!";
   const expectedOutput = "SGVsbG8sIFdvcmxkIQ==";
 
-    const encodedString = encodeStringToBase64Url(inputString);
-    t.is(encodedString, expectedOutput);
+  const encodedString = encodeStringToBase64Url(inputString);
+  t.is(encodedString, expectedOutput);
 });


### PR DESCRIPTION
This PR introduces `SentinelResponseDebugData`, which is a way for us to collect some debug information in case an end-user can not connect to our servers at all, but do end up submitting the form. This allows us to now whether it may be an issue affecting specific browsers, or a certain sitekey.

**Not ready to be merged yet - currently testing in ancient browsers**

