### PR TITLE
Prevent text selection on `Friendly Captcha` link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## Unreleased
+
+* Add `user-select: none` style to Friendly Captcha link to prevent text selection.
+
 ## 0.1.32
 
 * Fix rare case of wrongly resolving page language.

--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -162,6 +162,7 @@ export function createBanner(opts: CreateWidgetOptions) {
   const s = a.style;
   setCommonTextStyles(s);
   s.fontSize = "10px";
+  s.userSelect = "none";
 
   const isDark =
     opts.theme === "dark" ||


### PR DESCRIPTION
A small UX improvement, when selecting all text on a website that includes a widget, it will no longer include the `Friendly Captcha` link text