### PR TITLE
Publish npm package with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish to NPM
 
 permissions:
   contents: read
+  id-token: write  # for npm publish --provenance
 
 on:
   release:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "api-extractor": "api-extractor",
     "license-check-and-add": "license-check-and-add",
     "fmt": "prettier src/**/*.ts test/**/*.ts package.json babel.config.cjs --write",
-    "dist": "npm run clean && npm run build:dist && node prepublish.mjs && cd dist && npm publish",
+    "dist": "npm run clean && npm run build:dist && node prepublish.mjs && cd dist && npm publish --provenance --access public",
     "prepublishOnly": "echo \"Run npm run dist to build the package and publish it\" && exit 1"
   },
   "author": "Friendly Captcha GmbH",


### PR DESCRIPTION
- https://docs.npmjs.com/generating-provenance-statements
- https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow

I guess I can't test this without actually publishing a release, but I _think_ it should Just Work (TM).

A future improvement could be to remove long-lived tokens altogether and use trusted publishing: https://docs.npmjs.com/trusted-publishers