### PR TITLE
Bump actions versions, and pin nodejs 22.14.0 and npm@11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - name: Use Node.js 22.14.0
+      - name: Use Node.js 24.18.0
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          node-version: 24.18.0
           cache: "npm"
           cache-dependency-path: "package-lock.json"
       - name: "Install deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - name: Use Node.js 22.14.0
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.14.0
           cache: "npm"
           cache-dependency-path: "package-lock.json"
       - name: "Install deps"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.14.0'
+          node-version: '24.18.0'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g npm@11
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
       - run: npm ci
       - run: npm run build:dist
       - run: npm test


### PR DESCRIPTION
The Publish workflow was trying to install an npm version incompatible with node `20.x`:

```
Run npm install -g npm@latest
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-07-09T12_03_36_052Z-debug-0.log
Error: Process completed with exit code 1.
```