### PR TITLE
Cancel pending iframe load retries when a widget is destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 1.0.3
+
+- Fix a destroyed widget continuing to retry its iframe load, which logged retry warnings and could move the widget into an error state after it was destroyed. This shows up in React StrictMode, which mounts, unmounts and mounts again.
+
 ## 1.0.2
 
 - Lengthen the iframe load retry timeouts so that slow or lossy connections have more time to finish loading.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "exports": {

--- a/sdktest/test/destroy_cancels_retries/body.tmpl.html
+++ b/sdktest/test/destroy_cancels_retries/body.tmpl.html
@@ -1,0 +1,11 @@
+<main>
+    <form>
+        <p>A widget is created, destroyed, and created again on the same element, like React StrictMode does.</p>
+
+        <input type="textarea" />
+        <div id="mount"></div>
+        <input type="submit" />
+    </form>
+</main>
+
+<script defer src="main.tmpl.ts"></script>

--- a/sdktest/test/destroy_cancels_retries/config.yaml
+++ b/sdktest/test/destroy_cancels_retries/config.yaml
@@ -1,0 +1,1 @@
+api_endpoint: https://websitethatdefinitelydoesnotexist1234.com

--- a/sdktest/test/destroy_cancels_retries/main.tmpl.ts
+++ b/sdktest/test/destroy_cancels_retries/main.tmpl.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Friendly Captcha GmbH 2023.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { FriendlyCaptchaSDK } from "../../../dist/sdk.js";
+import { sdktest } from "../../sdktestlib/sdk.js";
+
+const sitekey = "{{.Config.Sitekey}}";
+// Unreachable, so every widget that is still alive keeps retrying its iframe load.
+const apiEndpoint = "{{.Config.APIEndpoint}}";
+const mount = document.querySelector("#mount") as HTMLElement;
+
+const retryWarnings: string[] = [];
+const originalWarn = console.warn.bind(console);
+console.warn = function (...args: any[]) {
+  if (typeof args[0] === "string" && args[0].indexOf("Retrying widget") !== -1) {
+    retryWarnings.push(args[0]);
+  }
+  originalWarn(...args);
+};
+
+const sdk = new FriendlyCaptchaSDK();
+
+// React StrictMode mounts, cleans up, and mounts again, so the first widget is destroyed
+// while its iframe load is still pending.
+const firstWidget = sdk.createWidget({ element: mount, sitekey, apiEndpoint });
+const firstWidgetId = firstWidget.id;
+firstWidget.destroy();
+const secondWidget = sdk.createWidget({ element: mount, sitekey, apiEndpoint });
+const secondWidgetId = secondWidget.id;
+
+const FIRST_RETRY_TIMEOUT = 3000;
+
+sdktest.description(
+  "A widget is destroyed before its iframe loads (as React StrictMode does). Only the widget that is still alive should retry.",
+);
+
+sdktest.test({ name: "only the second widget remains", sdk }, async (t) => {
+  t.require.numberOfWidgets(1);
+  t.assert.equal(true, firstWidget.isDestroyed);
+  t.assert.equal(secondWidgetId, t.getWidget()!.id);
+});
+
+sdktest.test({ name: "destroying a widget cancels its pending iframe retries", sdk, timeout: 25_000 }, async (t) => {
+  await new Promise((resolve) => setTimeout(resolve, FIRST_RETRY_TIMEOUT + 2000));
+
+  const strayWarnings = retryWarnings.filter((w) => w.indexOf(firstWidgetId) !== -1);
+  t.assert.equal(0, strayWarnings.length, `The destroyed widget logged ${strayWarnings.length} iframe retries`);
+
+  // Without this the test would also pass when no widget retries at all.
+  const liveWarnings = retryWarnings.filter((w) => w.indexOf(secondWidgetId) !== -1);
+  t.assert.notEqual(0, liveWarnings.length, "The widget that is still alive should retry its iframe load");
+});
+
+sdktest.test({ name: "the destroyed widget stays destroyed", sdk }, async (t) => {
+  t.assert.equal("destroyed", firstWidget.getState());
+  t.assert.equal(".DESTROYED", firstWidget.getResponse());
+});

--- a/sdktest/test/destroy_cancels_retries/main.tmpl.ts
+++ b/sdktest/test/destroy_cancels_retries/main.tmpl.ts
@@ -31,6 +31,7 @@ firstWidget.destroy();
 const secondWidget = sdk.createWidget({ element: mount, sitekey, apiEndpoint });
 const secondWidgetId = secondWidget.id;
 
+// Mirrors the first entry of IFRAME_LOAD_TIMEOUTS in src/sdk/sdk.ts.
 const FIRST_RETRY_TIMEOUT = 3000;
 
 sdktest.description(
@@ -44,7 +45,7 @@ sdktest.test({ name: "only the second widget remains", sdk }, async (t) => {
 });
 
 sdktest.test({ name: "destroying a widget cancels its pending iframe retries", sdk, timeout: 25_000 }, async (t) => {
-  await new Promise((resolve) => setTimeout(resolve, FIRST_RETRY_TIMEOUT + 2000));
+  await new Promise((resolve) => setTimeout(resolve, FIRST_RETRY_TIMEOUT + 1000));
 
   const strayWarnings = retryWarnings.filter((w) => w.indexOf(firstWidgetId) !== -1);
   t.assert.equal(0, strayWarnings.length, `The destroyed widget logged ${strayWarnings.length} iframe retries`);

--- a/src/communication/bus.ts
+++ b/src/communication/bus.ts
@@ -151,15 +151,15 @@ export class CommunicationBus {
       id: id,
       element: iframe,
       type: type,
-      onReady: () => fp.resolve("registered"),
+      onReady: () => {
+        // Without this the timer outlives a successful registration by up to its full duration.
+        clearTimeout(timeoutHandle);
+        fp.resolve("registered");
+      },
     });
     this.registerTarget(t);
 
-    // Clearing the timer on registration keeps a resolved race from holding on to it for its full duration.
-    return Promise.race([fp.promise, timeoutPromise]).then((status) => {
-      clearTimeout(timeoutHandle);
-      return status;
-    });
+    return Promise.race([fp.promise, timeoutPromise]);
   }
 
   /**

--- a/src/communication/bus.ts
+++ b/src/communication/bus.ts
@@ -143,7 +143,10 @@ export class CommunicationBus {
   ): Promise<"registered" | "timeout"> {
     const fp = flatPromise<"registered">();
     // Create a promise that resolves to `"timeout"` after some time.
-    let timeoutPromise = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), timeout));
+    let timeoutHandle: ReturnType<typeof setTimeout>;
+    let timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeout);
+    });
     const t = new IFrameCommunicationTarget({
       id: id,
       element: iframe,
@@ -152,7 +155,11 @@ export class CommunicationBus {
     });
     this.registerTarget(t);
 
-    return Promise.race([fp.promise, timeoutPromise]);
+    // Clearing the timer on registration keeps a resolved race from holding on to it for its full duration.
+    return Promise.race([fp.promise, timeoutPromise]).then((status) => {
+      clearTimeout(timeoutHandle);
+      return status;
+    });
   }
 
   /**

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -525,12 +525,8 @@ export class FriendlyCaptchaSDK {
       this.bus.send(mergeObject(msgToSend, msg));
     };
 
-    // Set on destroy so that a pending iframe load retry stops instead of touching a widget that is gone.
-    let destroyed = false;
-
     const callbacks = {
       onDestroy: () => {
-        destroyed = true;
         send({ type: "root_destroy_widget" });
         this.bus.removeTarget(widgetId);
         this.widgets.delete(widgetId);
@@ -599,7 +595,8 @@ export class FriendlyCaptchaSDK {
 
     const registerWithRetry = () => {
       this.bus.registerTargetIFrame("widget", widgetId, wel, this.getRetryTimeout(attempt)).then((status) => {
-        if (destroyed) return;
+        // Retrying a widget that was destroyed while its iframe was still loading is pointless.
+        if (widgetHandle.isDestroyed) return;
 
         if (status === "timeout") {
           if (attempt >= maxAttempts) {

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -383,6 +383,9 @@ export class FriendlyCaptchaSDK {
 
     const registerWithRetry = () => {
       this.bus.registerTargetIFrame("agent", agentId, el, this.getRetryTimeout(attempt)).then((status) => {
+        // The agent is no longer tracked once `clear()` runs, at which point retrying it is pointless.
+        if (this.agents.get(origin) !== el) return;
+
         if (status === "timeout") {
           if (attempt >= maxAttempts) {
             console.error(`[Friendly Captcha] Failed to load agent iframe after ${attempt - 1} retries.`);
@@ -522,8 +525,12 @@ export class FriendlyCaptchaSDK {
       this.bus.send(mergeObject(msgToSend, msg));
     };
 
+    // Set on destroy so that a pending iframe load retry stops instead of touching a widget that is gone.
+    let destroyed = false;
+
     const callbacks = {
       onDestroy: () => {
+        destroyed = true;
         send({ type: "root_destroy_widget" });
         this.bus.removeTarget(widgetId);
         this.widgets.delete(widgetId);
@@ -592,6 +599,8 @@ export class FriendlyCaptchaSDK {
 
     const registerWithRetry = () => {
       this.bus.registerTargetIFrame("widget", widgetId, wel, this.getRetryTimeout(attempt)).then((status) => {
+        if (destroyed) return;
+
         if (status === "timeout") {
           if (attempt >= maxAttempts) {
             console.error(`[Friendly Captcha] Failed to load widget iframe after ${attempt - 1} retries.`);


### PR DESCRIPTION
A user reported that a destroyed widget keeps logging `[Friendly Captcha] Retrying widget <id> iframe load.`, which reproduces in React StrictMode: it creates a widget, destroys it on cleanup, and creates a second one. The first widget's iframe request is aborted before it registers, so its retry chain is still pending when `destroy()` runs, and nothing cancels it. It's worse than the warning suggests, because the retry also calls `setUnreachableState()`, so the destroyed handle ends up in `error` with `.ERROR.UNREACHABLE` instead of `.DESTROYED`, and re-registering the target undoes the `removeTarget()` that destroy just did.

The widget retry chain now bails on `widgetHandle.isDestroyed`, which `destroy()` already sets before it runs the destroy callback. The agent chain had the same problem against `clear()`, and stops now when the iframe is no longer the tracked agent for its origin. Also cleared the timeout in `registerTargetIFrame`, which was holding a timer for up to 38 seconds after a successful registration.

Added an sdktest for the StrictMode sequence against an unreachable endpoint. It asserts the destroyed widget logs no retries while the live one does, so it can't pass by nothing retrying at all. Verified it fails on main with exactly the reported symptoms.
