### PR TITLE
Put guard context in frame params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.4
 
-- Add the `guardContext` option when creating a widget or generating a Risk Intelligence token to associate the event with a Friendly Guard screening flow if used in that context.
+- Add the `guardContext` SDK option to associate with a Friendly Guard screening flow if used in that context (no effect for normal implementations).
 
 ## 1.0.3
 

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -17,7 +17,6 @@ export interface CreateWidgetOptions {
     apiEndpoint?: APIEndpoint;
     element: HTMLElement;
     formFieldName?: string | null;
-    guardContext?: string;
     language?: string;
     sitekey?: string;
     startMode?: StartMode;
@@ -189,6 +188,7 @@ export class FriendlyCaptchaSDK {
 export interface FriendlyCaptchaSDKOptions {
     apiEndpoint?: APIEndpoint;
     disableEvalPatching?: boolean;
+    guardContext?: string;
     startAgent?: boolean;
 }
 
@@ -243,7 +243,6 @@ export class RiskIntelligenceHandle {
 export interface RiskIntelligenceOptions {
     apiEndpoint?: APIEndpoint;
     bypassCache?: boolean;
-    guardContext?: string;
     sitekey: string;
 }
 

--- a/etc/sdk.api.md
+++ b/etc/sdk.api.md
@@ -188,6 +188,7 @@ export class FriendlyCaptchaSDK {
 export interface FriendlyCaptchaSDKOptions {
     apiEndpoint?: APIEndpoint;
     disableEvalPatching?: boolean;
+    // @internal
     guardContext?: string;
     startAgent?: boolean;
 }

--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -24,7 +24,7 @@ const WIDGET_PLACEHOLDER_CLASSNAME = "frc-widget-placeholder";
 /**
  * @internal
  */
-export function createAgentIFrame(frcSDK: FriendlyCaptchaSDK, agentId: string, src: string) {
+export function createAgentIFrame(frcSDK: FriendlyCaptchaSDK, agentId: string, src: string, guardContext: string | undefined) {
   const frameParams: FrameParams = {
     origin: document.location.origin,
     sess_id: sessionId(),
@@ -35,6 +35,10 @@ export function createAgentIFrame(frcSDK: FriendlyCaptchaSDK, agentId: string, s
     agent_id: agentId,
     ts: Date.now().toString(),
   };
+
+  if (guardContext) {
+    frameParams.guard_c = guardContext;
+  }
   const el = document.createElement("iframe");
   el.className = AGENT_FRAME_CLASSNAME;
   el.dataset[FRAME_ID_DATASET_FIELD] = agentId;
@@ -55,6 +59,7 @@ export function createWidgetIFrame(
   widgetId: string,
   widgetUrl: string,
   opts: CreateWidgetOptions,
+  guardContext: string | undefined,
 ): HTMLIFrameElement {
   const el = document.createElement("iframe");
 
@@ -77,8 +82,8 @@ export function createWidgetIFrame(
     frameData.theme = opts.theme;
   }
 
-  if (opts.guardContext) {
-    frameData.guard_c = opts.guardContext;
+  if (guardContext) {
+    frameData.guard_c = guardContext;
   }
 
   if (supportAllowClipboardWrite) {

--- a/src/sdk/create.ts
+++ b/src/sdk/create.ts
@@ -77,6 +77,10 @@ export function createWidgetIFrame(
     frameData.theme = opts.theme;
   }
 
+  if (opts.guardContext) {
+    frameData.guard_c = opts.guardContext;
+  }
+
   if (supportAllowClipboardWrite) {
     el.allow = "clipboard-write";
   }

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -90,6 +90,14 @@ export interface FriendlyCaptchaSDKOptions {
    * may affect some hot reloading functionality for Webpack (in `dev` mode).
    */
   disableEvalPatching?: boolean;
+
+  /**
+   * Opaque context that associates this SDK creates with a Friendly Guard screening flow.
+   * You should never need to set this option, this is for (internal) Friendly Guard interstitial integrations only.
+   * 
+   * @internal
+   */
+  guardContext?: string;
 }
 
 /**
@@ -115,6 +123,12 @@ let sdkC = 0;
  */
 export class FriendlyCaptchaSDK {
   private apiEndpoint?: APIEndpoint;
+
+  /**
+   * The Friendly Guard context for this page (not relevant for ordinary Friendly Captcha integrations).
+   * @internal
+   */
+  private guardContext?: string;
 
   /**
    * Multiple agents may be running at the same time, this is the case if someone uses widgets with different endpoints on a single page.
@@ -177,6 +191,7 @@ export class FriendlyCaptchaSDK {
 
   constructor(opts: FriendlyCaptchaSDKOptions = {}) {
     this.apiEndpoint = opts.apiEndpoint;
+    this.guardContext = opts.guardContext;
 
     cbus = cbus || new CommunicationBus();
     cbus.listen((msg: EnvelopedMessage<Message>) => this.onReceiveMessage(msg as EnvelopedMessage<ToRootMessage>));
@@ -372,7 +387,7 @@ export class FriendlyCaptchaSDK {
     }
 
     const agentId = "a_" + randomId(12);
-    const el = createAgentIFrame(this, agentId, src);
+    const el = createAgentIFrame(this, agentId, src, this.guardContext);
     el.dataset[AGENT_ORIGIN_KEY_DATASET_FIELD] = origin;
     const initialSrc = el.src;
     let currentOrigin = origin;
@@ -553,7 +568,7 @@ export class FriendlyCaptchaSDK {
     this.widgets.set(widgetId, widgetHandle);
 
     const widgetUrl = origin + widgetEndpoint;
-    const wel = createWidgetIFrame(agentId, widgetId, widgetUrl, opts);
+    const wel = createWidgetIFrame(agentId, widgetId, widgetUrl, opts, this.guardContext);
     const maxAttempts = MAX_IFRAME_LOAD_ATTEMPTS;
     const initialSrc = wel.src;
     let currentOrigin = origin;
@@ -653,7 +668,6 @@ export class FriendlyCaptchaSDK {
       from_id: "",
       _frc: 1,
       sitekey: opts.sitekey,
-      guard_context: opts.guardContext,
       bypassCache: opts.bypassCache || false,
       uid,
     });

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -92,7 +92,7 @@ export interface FriendlyCaptchaSDKOptions {
   disableEvalPatching?: boolean;
 
   /**
-   * Opaque context that associates this SDK creates with a Friendly Guard screening flow.
+   * Opaque context that associates this SDK with a Friendly Guard screening flow.
    * You should never need to set this option, this is for (internal) Friendly Guard interstitial integrations only.
    * 
    * @internal

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -629,11 +629,6 @@ export class FriendlyCaptchaSDK {
       });
     };
     registerWithRetry();
-
-    if (opts.guardContext) {
-      send({ type: "root_set_guard_context", guard_context: opts.guardContext });
-    }
-
     registered.resolve();
 
     return widgetHandle;

--- a/src/types/frameParams.ts
+++ b/src/types/frameParams.ts
@@ -55,5 +55,10 @@ export type FrameParams = {
    */
   theme?: string;
 
+  /**
+   * Opaque context that associates this frame with a Friendly Guard screening flow.
+   */
+  guard_c?: string;
+
   expire?: string;
 };

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -183,7 +183,6 @@ export interface RootRiskIntelligenceGenerateMessage {
   type: "root_risk_intelligence_generate";
   uid: string;
   sitekey: string;
-  guard_context?: string;
   bypassCache: boolean;
 }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -20,7 +20,6 @@ export type ToAgentMessage =
   | RootDestroyWidgetMessage
   | RootResetWidgetMessage
   | RootTriggerWidgetMessage
-  | RootSetGuardContextMessage
   | RootStoreSetReplyMessage
   | RootStoreGetReplyMessage
   | RootSignalsGetReplyMessage
@@ -106,11 +105,6 @@ export interface RootResetWidgetMessage {
 
 export interface RootDestroyWidgetMessage {
   type: "root_destroy_widget";
-}
-
-export interface RootSetGuardContextMessage {
-  type: "root_set_guard_context";
-  guard_context: string;
 }
 // Messages to the widget from the agent
 

--- a/src/types/riskIntelligence.ts
+++ b/src/types/riskIntelligence.ts
@@ -12,12 +12,6 @@ export interface RiskIntelligenceOptions {
   sitekey: string;
 
   /**
-   * Opaque context used to associate a Risk Intelligence flow with Friendly Guard.
-   * Only used by Friendly Guard integrations and is set by the interstitial renderer. End users should never need to set this parameter.
-   */
-  guardContext?: string;
-
-  /**
    * A custom endpoint from which the agent is loaded and to which Risk Intelligence
    * requests are made.
    */

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -153,12 +153,6 @@ export interface CreateWidgetOptions {
   sitekey?: string;
 
   /**
-   * Opaque context used to associate a widget flow with a Friendly Guard screening flow.
-   * Only used by Friendly Guard integrations and is set by the interstitial renderer. End users should never need to set this parameter.
-   */
-  guardContext?: string;
-
-  /**
    * The name of the field in the form that is set, defaults to `frc-captcha-response`.
    */
   formFieldName?: string | null;


### PR DESCRIPTION
Pointed at #101. Note that for risk intelligence it's still sent as before in the `root_risk_intelligence_generate` message which has a field `guard_context`. 

An alternative could be to put it in the frame params for the agent as well, not sure if/how that would be preferable. I imagine either can work equally well, perhaps frame params has the advantage of being able to know for the agent request already what guard flow it's a part of?