### PR TITLE
Support meta tag for setting guard context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # changelog
 
-## 1.0.4
+## 1.1.1
+- Add support for setting the `guardContext` value introduced in `1.1.0` through a HTML meta tag.
+
+## 1.1.0
 
 - Add the `guardContext` SDK option to associate with a Friendly Guard screening flow if used in that context (no effect for normal implementations).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendlycaptcha/sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@ava/typescript": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendlycaptcha/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "In-browser SDK for Friendly Captcha v2",
   "main": "dist/sdk.js",
   "exports": {

--- a/sdktest/test/shadow_dom_focus/main.tmpl.ts
+++ b/sdktest/test/shadow_dom_focus/main.tmpl.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) Friendly Captcha GmbH 2026.
+ * Copyright (c) Friendly Captcha GmbH 2023.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/sdk/options.ts
+++ b/src/sdk/options.ts
@@ -42,18 +42,26 @@ export function resolveAPIOrigins(optionValue: string | undefined): string[] {
   return splitCSV(SHORTHANDS.global).map(originOf);
 }
 
-export function getSDKDisableEvalPatching(): boolean {
-  // We check if the meta tag `frc-disable-eval-patching` is present.
-  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-disable-eval-patching"]`);
-  if (!m) return false;
+/**
+ * Returns the content of the `<meta name="frc-{name}">` tag, or undefined if there is no such tag.
+ */
+function getMetaContent(name: string): string | undefined {
+  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-${name}"]`);
+  return m ? m.content : undefined;
+}
 
-  return !!m.content;
+export function getSDKDisableEvalPatching(): boolean {
+  return !!getMetaContent("disable-eval-patching");
+}
+
+export function getSDKGuardContext(): string | undefined {
+  return getMetaContent("guard-context");
 }
 
 export function getSDKAPIEndpoint(): string | undefined {
   // 1. We check for the meta tag `frc-api-endpoint`
-  const m: HTMLMetaElement | null = document.querySelector(`meta[name="frc-api-endpoint"]`);
-  if (m) return m.content;
+  const m = getMetaContent("api-endpoint");
+  if (m) return m;
 
   // 2. We check the current script element for `data-frc-api-endpoint`.
   const cs = document.currentScript;

--- a/src/sdk/riskIntelligenceHandle.ts
+++ b/src/sdk/riskIntelligenceHandle.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) Friendly Captcha GmbH 2026.
+ * Copyright (c) Friendly Captcha GmbH 2023.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -34,7 +34,7 @@ import { Signals, getSignals } from "../signals/collect.js";
 import { stringHasPrefix } from "../util/string.js";
 import { mergeObject } from "../util/object.js";
 import { _RootTrigger } from "../types/trigger.js";
-import { resolveAPIOrigins, getSDKAPIEndpoint, getSDKDisableEvalPatching } from "./options.js";
+import { resolveAPIOrigins, getSDKAPIEndpoint, getSDKDisableEvalPatching, getSDKGuardContext } from "./options.js";
 import { SentinelResponseDebugData } from "../types/sentinel.js";
 import { tz } from "../util/tz.js";
 import { encodeStringToBase64Url } from "../util/encode.js";
@@ -191,7 +191,7 @@ export class FriendlyCaptchaSDK {
 
   constructor(opts: FriendlyCaptchaSDKOptions = {}) {
     this.apiEndpoint = opts.apiEndpoint;
-    this.guardContext = opts.guardContext;
+    this.guardContext = opts.guardContext || getSDKGuardContext();
 
     cbus = cbus || new CommunicationBus();
     cbus.listen((msg: EnvelopedMessage<Message>) => this.onReceiveMessage(msg as EnvelopedMessage<ToRootMessage>));


### PR DESCRIPTION
Introduces support for a meta tag `<meta name="frc-guard-context">` to set the guard context. This is useful for Friendly Guard implementations that don't want to programmatically create the SDK.

Unrelated change: this changes two of the license headers to be the same as all the other ones. Without this change we introduce a license comment twice in the output build (one for each year present), this saves ~255 bytes.